### PR TITLE
Define custom rules for JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,12 @@ module.exports = {
     printWidth: 120,
     semi: false,
     singleQuote: true,
+    overrides: [
+    {
+      files: ['*.json'],
+      options: {
+        trailingComma: 'none',
+      },
+    },
+  ],
 }


### PR DESCRIPTION
Since prettier 3.0, trailingComma is set to 'all' which leads to a faulty JSON format.