### PR TITLE
Explicitly use json parser for .json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ module.exports = {
 }
 ```
 
+## Notes
+We explicitely parse .json files as JSON which differs from the behavior within prettier itself where certain files are assigned to JSON5 or JSONC.
+
 ## Contribute
 
 To setup current node version, you can use [nvm](https://github.com/nvm-sh/nvm)

--- a/index.js
+++ b/index.js
@@ -4,4 +4,12 @@ module.exports = {
     printWidth: 120,
     semi: false,
     singleQuote: true,
+    overrides: [
+      {
+        files: '*.json',
+        options: {
+            parser: 'json'
+        }
+      }
+    ]
 }


### PR DESCRIPTION
Alongside the discussion in the prettier issues, json files are not always parsed as JSON but rather JSONC or JSON5. Here, prettier doesn't render files according to their file extension. We, on the other hand, work that way so it's necessary to explicitly set the parser to avoid trailing commas in JSON files.